### PR TITLE
Add Apache 2.0 exception to enable GPLv2 compatibility

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -173,4 +173,19 @@
       incurred by, or claims asserted against, such Contributor by reason
       of your accepting any such warranty or additional liability.
 
+---- Exceptions to the Apache 2.0 License ----
+
+As an exception, if, as a result of your compiling your source code, portions of
+this Software are embedded into an Object form of such source code, you may
+redistribute such embedded portions in such Object form without complying with
+the conditions of Sections 4(a), 4(b) and 4(d) of the License.
+
+In addition, if you combine or link compiled forms of this Software with
+software that is licensed under the GPLv2 ("Combined Software") and if a court
+of competent jurisdiction determines that the patent provision (Section 3), the
+indemnity provision (Section 9) or other Section of the License conflicts with
+the conditions of the GPLv2, you may retroactively and prospectively choose to
+deem waived or otherwise exclude such Section(s) of the License, but only in
+their entirety and only with respect to the Combined Software.
+
    END OF TERMS AND CONDITIONS


### PR DESCRIPTION
These exceptions are used by LLVM to enable Apache 2.0 license code to be used with GPLv2 licensed code.

See some discussion here
https://lists.llvm.org/pipermail/llvm-dev/2016-September/104778.html for background.

These exceptions have been taken from the LLVM license: https://llvm.org/LICENSE.txt