### PR TITLE
Update SPDX-License-Identifier

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -173,7 +173,7 @@
       incurred by, or claims asserted against, such Contributor by reason
       of your accepting any such warranty or additional liability.
 
----- Exceptions to the Apache 2.0 License ----
+---- LLVM Exceptions to the Apache 2.0 License ----
 
 As an exception, if, as a result of your compiling your source code, portions of
 this Software are embedded into an Object form of such source code, you may

--- a/riscv-sw/build-flow/Makefile.include
+++ b/riscv-sw/build-flow/Makefile.include
@@ -1,6 +1,6 @@
 # Copyright 2021 Gregory Chadwick <mail@gregchadwick.co.uk>
-# Licensed under the Apache License, Version 2.0, see LICENSE for details.
-# SPDX-License-Identifier: Apache-2.0
+# Licensed under the Apache License Version 2.0, with LLVM Exceptions, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 RISCV_SW_PATH = $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 

--- a/riscv-sw/build-flow/crt0.s
+++ b/riscv-sw/build-flow/crt0.s
@@ -1,6 +1,6 @@
 # Copyright 2021 Gregory Chadwick <mail@gregchadwick.co.uk>
-# Licensed under the Apache License, Version 2.0, see LICENSE for details.
-# SPDX-License-Identifier: Apache-2.0
+# Licensed under the Apache License Version 2.0, with LLVM Exceptions, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 .section .text.start
 

--- a/riscv-sw/build-flow/link.ld
+++ b/riscv-sw/build-flow/link.ld
@@ -1,6 +1,6 @@
 /* Copyright 2021 Gregory Chadwick <mail@gregchadwick.co.uk>
-   Licensed under the Apache License, Version 2.0, see LICENSE for details.
-   SPDX-License-Identifier: Apache-2.0 */
+   Licensed under the Apache License Version 2.0, with LLVM Exceptions, see LICENSE for details.
+   SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception */
 
 OUTPUT_ARCH(riscv)
 

--- a/riscv-sw/examples/hello_world/Makefile
+++ b/riscv-sw/examples/hello_world/Makefile
@@ -1,6 +1,6 @@
 # Copyright 2021 Gregory Chadwick <mail@gregchadwick.co.uk>
-# Licensed under the Apache License, Version 2.0, see LICENSE for details.
-# SPDX-License-Identifier: Apache-2.0
+# Licensed under the Apache License Version 2.0, with LLVM Exceptions, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 PROG_NAME = hello_world
 

--- a/riscv-sw/examples/hello_world/hello_world.c
+++ b/riscv-sw/examples/hello_world/hello_world.c
@@ -1,6 +1,6 @@
 // Copyright 2021 Gregory Chadwick <mail@gregchadwick.co.uk>
-// Licensed under the Apache License, Version 2.0, see LICENSE for details.
-// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License Version 2.0, with LLVM Exceptions, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 
 #include <stdint.h>

--- a/rrs-cli/src/main.rs
+++ b/rrs-cli/src/main.rs
@@ -1,6 +1,6 @@
 // Copyright 2021 Gregory Chadwick <mail@gregchadwick.co.uk>
-// Licensed under the Apache License, Version 2.0, see LICENSE for details.
-// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License Version 2.0, with LLVM Exceptions, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 use clap::{clap_app, ArgMatches};
 use rrs_lib::instruction_executor::{InstructionExecutor, InstructionTrap};

--- a/rrs-lib/src/csrs.rs
+++ b/rrs-lib/src/csrs.rs
@@ -1,6 +1,6 @@
 // Copyright 2021 Gregory Chadwick <mail@gregchadwick.co.uk>
-// Licensed under the Apache License, Version 2.0, see LICENSE for details.
-// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License Version 2.0, with LLVM Exceptions, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 use super::CSR;
 use num_enum::{IntoPrimitive, TryFromPrimitive};

--- a/rrs-lib/src/instruction_executor.rs
+++ b/rrs-lib/src/instruction_executor.rs
@@ -1,6 +1,6 @@
 // Copyright 2021 Gregory Chadwick <mail@gregchadwick.co.uk>
-// Licensed under the Apache License, Version 2.0, see LICENSE for details.
-// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License Version 2.0, with LLVM Exceptions, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 //! An [InstructionProcessor] that executes instructions.
 //!

--- a/rrs-lib/src/instruction_formats.rs
+++ b/rrs-lib/src/instruction_formats.rs
@@ -1,6 +1,6 @@
 // Copyright 2021 Gregory Chadwick <mail@gregchadwick.co.uk>
-// Licensed under the Apache License, Version 2.0, see LICENSE for details.
-// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License Version 2.0, with LLVM Exceptions, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 //! Structures and constants for instruction decoding
 //!

--- a/rrs-lib/src/instruction_string_outputter.rs
+++ b/rrs-lib/src/instruction_string_outputter.rs
@@ -1,6 +1,6 @@
 // Copyright 2021 Gregory Chadwick <mail@gregchadwick.co.uk>
-// Licensed under the Apache License, Version 2.0, see LICENSE for details.
-// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License Version 2.0, with LLVM Exceptions, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 //! An [InstructionProcessor] that outputs a string of the instruction disassembly
 //!

--- a/rrs-lib/src/lib.rs
+++ b/rrs-lib/src/lib.rs
@@ -1,6 +1,6 @@
 // Copyright 2021 Gregory Chadwick <mail@gregchadwick.co.uk>
-// Licensed under the Apache License, Version 2.0, see LICENSE for details.
-// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License Version 2.0, with LLVM Exceptions, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 //! RISC-V instruction set simulator library
 //!

--- a/rrs-lib/src/memories.rs
+++ b/rrs-lib/src/memories.rs
@@ -1,6 +1,6 @@
 // Copyright 2021 Gregory Chadwick <mail@gregchadwick.co.uk>
-// Licensed under the Apache License, Version 2.0, see LICENSE for details.
-// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License Version 2.0, with LLVM Exceptions, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 //! Various [Memory] implementations useful for an ISS and utility functions
 

--- a/rrs-lib/src/process_instruction.rs
+++ b/rrs-lib/src/process_instruction.rs
@@ -1,6 +1,6 @@
 // Copyright 2021 Gregory Chadwick <mail@gregchadwick.co.uk>
-// Licensed under the Apache License, Version 2.0, see LICENSE for details.
-// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License Version 2.0, with LLVM Exceptions, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 use super::instruction_formats;
 use super::InstructionProcessor;


### PR DESCRIPTION
Project now uses 'Apache-2.0 WITH LLVM-exception'